### PR TITLE
Use constant-velocity shapes to calculate complexity metrics

### DIFF
--- a/_Scripts/1_preprocessing.R
+++ b/_Scripts/1_preprocessing.R
@@ -65,7 +65,8 @@ turnangledat <- segments %>%
     ~ get_fig_points(tvals,
       .x$start.x, .x$start.y,
       .x$end.x, .x$end.y,
-      .x$ctrl.x, .x$ctrl.y
+      .x$ctrl.x, .x$ctrl.y,
+      equidist = TRUE, n = 150
     )
   ) %>%
   mutate(

--- a/_Scripts/_functions/complexity.R
+++ b/_Scripts/_functions/complexity.R
@@ -43,7 +43,9 @@ bezier_length <- function(start.x, start.y, end.x, end.y, ctrl.x, ctrl.y) {
 }
 
 
-get_fig_points <- function(t, start.x, start.y, end.x, end.y, ctrl.x, ctrl.y) {
+get_fig_points <- function(
+  t, start.x, start.y, end.x, end.y, ctrl.x, ctrl.y, equidist = FALSE, n = 150
+) {
 
   # Define constants and transition values
   ax <- start.x - ctrl.x
@@ -58,6 +60,21 @@ get_fig_points <- function(t, start.x, start.y, end.x, end.y, ctrl.x, ctrl.y) {
     x = as.vector(t(ctrl.x + ax * (1 - tmat) ** 2 + bx * tmat ** 2)),
     y = as.vector(t(ctrl.y + ay * (1 - tmat) ** 2 + by * tmat ** 2))
   )
+
+  # Optionally reinterpolate figure points to have constant velocity, better
+  # matching the way figures are animated on screen
+  if (equidist) {
+
+    dists <- sqrt((pts$x - lag(pts$x)) ^ 2 + (pts$y - lag(pts$y)) ^ 2)
+    dists[1] <- 0
+    steps <- cumsum(dists)
+
+    pts <- tibble(
+      x = approx(steps, pts$x, n = n, method = "linear", ties = "ordered")$y,
+      y = approx(steps, pts$y, n = n, method = "linear", ties = "ordered")$y
+    )
+  }
+
   pts
 }
 


### PR DESCRIPTION
Noticed this while looking over the complexity metrics: at present, we calculate most of these by 1) generating a new figure from the shape's bezier segments (so animation speed doesn't affect complexity), 2) calculating the changes in turn angle along it, and 3) calculating a series of complexity metrics based on those generated points (turn angle sum, turn angle SD, approx/sample entropy).

The problem is because each bezier is turned into an equal number of points and also beziers aren't naturally constant-velocity, you get a ton of points close together in small segments and spaced out much further (and unevenly) in the large segments, which throws off the entropy and turn angle SD calculations relative to the constant-velocity figures that people actually saw:
<img width="824" alt="Screenshot 2024-02-22 at 6 05 41 PM" src="https://github.com/LBRF/TraceLabAnalysis/assets/18648066/76ef08a2-69da-479b-b3f5-e0a4f635d1be">

The current PR modifies the `get_fig_points` function to allow reinterpolating generated figures to be equidistant, making them match the actual animation frames more closely:

<img width="824" alt="Screenshot 2024-02-22 at 6 05 32 PM" src="https://github.com/LBRF/TraceLabAnalysis/assets/18648066/91de7af6-c6e0-477b-9fcd-94bf02d66b11">

It uses a few more CPU cycles, but is still pretty quick and halves the RAM eaten up by the `turnangle_dat` data frame since each figure is now only 150 points (2.5 seconds at 60 fps) instead of 300, and likewise speeds up the subsequent complexity summarization since there's half as many data points to crunch.

Does my thinking make sense here? Or is there something preferable about the old method that I'm missing? I don't think `turnangle_sum` really gets affected by this, but the other metrics do.