### PR TITLE
Show progress messages for 0_import.R

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ These scripts are designed to be a template that different TraceLab analyses can
 All dependencies for these scripts can be installed by running the following line:
 
 ```r
-install.packages(c("tidyverse", "TSEntropies", "vegan", "dtw"))
+install.packages(c("tidyverse", "progress", "TSEntropies", "vegan", "dtw"))
 ```
 
 The scripts have been developed and tested on R 3.6. They may work with older versions of R but are not guaranteed to function correctly.

--- a/_Scripts/_functions/utils.R
+++ b/_Scripts/_functions/utils.R
@@ -1,0 +1,19 @@
+### Miscellaneous utility functions for the pipeline ###
+
+
+# Extracts the data for a given trial from a dataframe
+
+get_trial <- function(dat, p_num, s_num, b_num, t_num) {
+  subset(dat, id == p_num & session == s_num & block == b_num & trial == t_num)
+}
+
+
+# Prints a progress message to the console when running scripts with 'source()'
+
+progress_msg <- function(msg, header = FALSE) {
+  if (header) {
+    cat("\n=== ", msg, " ===\n\n")
+  } else {
+    cat(" * ", msg, "...\n")
+  }
+}

--- a/_Scripts/_functions/visualization.R
+++ b/_Scripts/_functions/visualization.R
@@ -6,21 +6,13 @@
 library(tidyr)
 library(ggplot2)
 
+source("./_Scripts/_functions/utils.R")
+
 
 
 ### Load per-project settings ###
 
 source("./_Scripts/_settings.R")
-
-
-
-### Utility Functions ###
-
-# Extracts the data for a given trial from a dataframe
-
-get_trial <- function(dat, p_num, s_num, b_num, t_num) {
-  subset(dat, id == p_num & session == s_num & block == b_num & trial == t_num)
-}
 
 
 


### PR DESCRIPTION
This PR adds some milestone messages when running `_Scripts/0_import.R`, so it's not just sitting there for a few minutes when loading a big dataset. It also uses the 'progress' package to show live progress when importing raw figure data, which is one of the slowest parts of the import process:

https://github.com/LBRF/TraceLabAnalysis/assets/18648066/69403b53-afbd-4215-beb3-4f8a5c06d5ae

Just a small quality-of-life improvement vs watching a stationary R prompt, wondering when an import is going to end.