### PR TITLE
Misc minor fixes and cleanup

### DIFF
--- a/_Scripts/1_preprocessing.R
+++ b/_Scripts/1_preprocessing.R
@@ -44,14 +44,9 @@ figsummary <- segments %>%
   summarize(
     real_length = sum(curve_len),
     total_point_dist = sum(line_len),
-    totabscurv = total_abs_curvature(
-      start.x, start.y,
-      end.x, end.y,
-      ctrl.x, ctrl.y
-    )
   ) %>%
   mutate(sinuosity = real_length / total_point_dist) %>%
-  select(c(1:trial, real_length, sinuosity, totabscurv))
+  select(c(1:trial, real_length, sinuosity))
 
 
 # Calcuate turning angle for entropy metrics

--- a/_Scripts/_functions/complexity.R
+++ b/_Scripts/_functions/complexity.R
@@ -62,9 +62,6 @@ get_fig_points <- function(t, start.x, start.y, end.x, end.y, ctrl.x, ctrl.y) {
 }
 
 
-
-### Total absolute curvature functions ###
-
 bcurv <- function(t, start.x, start.y, end.x, end.y, ctrl.x, ctrl.y) {
 
   # Calculate first derivatives of bezier for x and y
@@ -79,31 +76,6 @@ bcurv <- function(t, start.x, start.y, end.x, end.y, ctrl.x, ctrl.y) {
   curv <- ((b1x * b2y) - (b1y * b2x)) / (((b1x^2) + (b1y^2)) ^ (3 / 2))
 
   curv
-}
-
-
-total_abs_curvature <- function(start.x, start.y, end.x, end.y, ctrl.x, ctrl.y) {
-
-  # Calculate total absolute curvature of each segment and sum:
-  # note, this essentially misses the spikes in curvature created by
-  # segment intersections. Consider using turning angle.
-
-  # NOTE: This metric doesn't correlate with any of the other complexity
-  # measures, may be calculating wrong. Revisit and rethink before using.
-
-  t <- seq(0, 1, length = 60)
-  seg_count <- length(start.x)
-  curvatures <- sapply(seq_len(seg_count), function(i) {
-    curv <- bcurv(t,
-      start.x[i], start.y[i],
-      end.x[i], end.y[i],
-      ctrl.x[i], ctrl.y[i]
-    )
-    integrate(splinefun(x = t, y = abs(curv)), 0, 1)$value
-  })
-  totabscurv <- sum(curvatures)
-
-  totabscurv
 }
 
 

--- a/_Scripts/_functions/physical.R
+++ b/_Scripts/_functions/physical.R
@@ -44,8 +44,8 @@ reinterpolate <- function(x, y, time, equidistant = FALSE, fps = 60, n = NA) {
 
   # Return new interpolated points
   interpolated <- tibble(
-    x = approx(steps, x, n = out_num, method = "linear")$y,
-    y = approx(steps, y, n = out_num, method = "linear")$y
+    x = approx(steps, x, n = out_num, method = "linear", ties = "ordered")$y,
+    y = approx(steps, y, n = out_num, method = "linear", ties = "ordered")$y
   )
 
   interpolated

--- a/_Scripts/_functions/visualization.R
+++ b/_Scripts/_functions/visualization.R
@@ -128,7 +128,7 @@ plot_trials <- function(trials, samples, color_code = NULL, outdir = ".") {
   }
 
   # Render and save a PDF plot for each trial in trials
-  for (i in 1:nrow(trials)) {
+  for (i in seq_len(nrow(trials))) {
     vals <- trials[i, ]
     fname <- paste0(paste(
       paste0("p", vals$id), paste0("s", vals$session),
@@ -162,7 +162,7 @@ plot_trial_paths <- function(trials, frames, samples, outdir = ".") {
   }
 
   # Render and save a PDF plot for each trial in trials
-  for (i in 1:nrow(trials)) {
+  for (i in seq_len(nrow(trials))) {
     vals <- trials[i, ]
     fname <- paste0(paste(
       paste0("p", vals$id), paste0("s", vals$session),


### PR DESCRIPTION
This PR contains a few unrelated changes that were too small to warrant their own separate PRs:

### Removal of Total Absolute Curvature as a complexity metric

We've always been iffy on this one because a) we've never been sure if it's really doing what it's supposed to, b) by definition it doesn't capture angle changes *between* segments as part of its complexity measure, and c) it didn't seem to correlate with any of the other error metrics.

This time around, I re-did all the correlations between complexity measures and also tested how well they correlated with tracing error for random shapes, and I think it's safe to say that this one's a dud. I can't think of any reason we'd ever want to to use it over turn angle sum, sinuosity, or even path length, which all show much larger and clearer correlations with tracing error than this does. This PR removes it entirely to simplify the script and avoid future confusion.

### Fixes an occasional interpolation warning/issue

Apparently by default `approx` doesn't assume its input steps are sequentially ordered, so it can throw a warning whenever there are two points with the same x or y position within the same shape. This PR adds an argument specifying the data is ordered so that's no longer a problem.

### Fixes an error when trying to generate plots for empty filters

This has happened a few times with students in the past year: basically, if `plot_filters` is true and but a filter doesn't catch any trials (e.g. no hand noise trials), due to an indexing bug in our code it'll throw an error instead of just doing nothing. This PR fixes that by using `seq_len`.