### PR TITLE
Improve Tracing Filters

### DIFF
--- a/_Scripts/1_preprocessing.R
+++ b/_Scripts/1_preprocessing.R
@@ -141,27 +141,6 @@ trial_key <- c("id", "session", "block", "trial")
 responsedat <- anti_join(responsedat, no_shape_trials, by = trial_key)
 
 
-# Trim extra points following failed trial end
-
-responsedat <- responsedat %>%
-  mutate(timediff = ifelse(is.na(lag(time)), 0, time - lag(time))) %>%
-  mutate(done = trial_done(origin.dist, timediff, done_filter_params))
-
-failed_end_trials <- responsedat %>%
-  summarize(
-    samples = n(),
-    num_done = sum(done),
-    mt_diff = max(time[!done]) - max(time),
-    prop_remaining = 1 - (sum(done) / n())
-  ) %>%
-  filter(num_done > 0)
-
-if (plot_filters) {
-  plot_trials(failed_end_trials, responsedat, "done", "./filters/done")
-}
-responsedat <- subset(responsedat, !done)
-
-
 # Flag and remove glitch points during tracings
 
 responsedat <- responsedat %>%
@@ -181,6 +160,27 @@ if (plot_filters) {
   plot_trials(glitch_trials, responsedat, "glitch", "./filters/glitch")
 }
 responsedat <- subset(responsedat, !glitch)
+
+
+# Trim extra points following failed trial end
+
+responsedat <- responsedat %>%
+  mutate(timediff = ifelse(is.na(lag(time)), 0, time - lag(time))) %>%
+  mutate(done = trial_done(origin.dist, timediff, done_filter_params))
+
+failed_end_trials <- responsedat %>%
+  summarize(
+    samples = n(),
+    num_done = sum(done),
+    mt_diff = max(time[!done]) - max(time),
+    prop_remaining = 1 - (sum(done) / n())
+  ) %>%
+  filter(num_done > 0)
+
+if (plot_filters) {
+  plot_trials(failed_end_trials, responsedat, "done", "./filters/done")
+}
+responsedat <- subset(responsedat, !done)
 
 
 # Flag and remove false start samples

--- a/_Scripts/1_preprocessing.R
+++ b/_Scripts/1_preprocessing.R
@@ -141,6 +141,30 @@ trial_key <- c("id", "session", "block", "trial")
 responsedat <- anti_join(responsedat, no_shape_trials, by = trial_key)
 
 
+# Remove 2nd shape on trials where participant draws the shape twice
+
+responsedat <- responsedat %>%
+  mutate(timediff = ifelse(is.na(lag(time)), 0, time - lag(time))) %>%
+  mutate(
+    done = trial_done(origin.dist, timediff, redraw_filter_params),
+    done = done & (sum(!done) / n()) < redraw_filter_params$max_prop
+  )
+
+redrawn_shape_trials <- responsedat %>%
+  summarize(
+    samples = n(),
+    num_done = sum(done),
+    mt_diff = max(time[!done]) - max(time),
+    prop_remaining = 1 - (sum(done) / n())
+  ) %>%
+  filter(num_done > 0)
+
+if (plot_filters) {
+  plot_trials(redrawn_shape_trials, responsedat, "done", "./filters/redrawn")
+}
+responsedat <- subset(responsedat, !done)
+
+
 # Flag and remove glitch points during tracings
 
 responsedat <- responsedat %>%

--- a/_Scripts/1_preprocessing.R
+++ b/_Scripts/1_preprocessing.R
@@ -167,23 +167,27 @@ responsedat <- subset(responsedat, !done)
 
 # Flag and remove glitch points during tracings
 
-responsedat <- responsedat %>%
-  mutate(angle_diff = (get_angle_diffs(x - lag(x), y - lag(y)) / pi) * 180) %>%
-  mutate(
-    glitch = is_glitch(x, y, angle_diff, origin.dist, glitch_filter_params)
-  )
+if (glitch_filter_params$enable) {
 
-glitch_trials <- responsedat %>%
-  summarize(
-    samples = n(),
-    glitches = sum(glitch)
-  ) %>%
-  filter(glitches > 0)
+  responsedat <- responsedat %>%
+    mutate(
+      angle_diff = (get_angle_diffs(x - lag(x), y - lag(y)) / pi) * 180,
+      glitch = is_glitch(x, y, angle_diff, origin.dist, glitch_filter_params)
+    )
 
-if (plot_filters) {
-  plot_trials(glitch_trials, responsedat, "glitch", "./filters/glitch")
+  glitch_trials <- responsedat %>%
+    summarize(
+      samples = n(),
+      glitches = sum(glitch)
+    ) %>%
+    filter(glitches > 0)
+
+  if (plot_filters) {
+    plot_trials(glitch_trials, responsedat, "glitch", "./filters/glitch")
+  }
+  responsedat <- subset(responsedat, !glitch)
+
 }
-responsedat <- subset(responsedat, !glitch)
 
 
 # Trim extra points following failed trial end

--- a/_Scripts/_functions/filters.R
+++ b/_Scripts/_functions/filters.R
@@ -76,6 +76,14 @@ is_glitch <- function(x, y, angle_diff, origin_dist, params) {
     angle_glitch <- angle_glitch & (lead(angle_glitch, 2) | sharp_angle_alt)
   }
 
+  # If multiple glitches in a row, check if the second one is actually a glitch
+  # (i.e. further than min_dist from last non-glitch point)
+  if (sum(angle_glitch) > 2) {
+    maybe_midpoint <- angle_glitch & !lag(angle_glitch, 2) & lag(angle_glitch)
+    dist_lag <- sqrt((x - lag(x, 2)) ** 2 + (y - lag(y, 2)) ** 2)
+    angle_glitch <- angle_glitch & !(maybe_midpoint & dist_lag < min_dist)
+  }
+
   # Catch consecutive glitch points, which often have either the same x or y
   # value as the previous/subsequent glitch
   before <- !is.na(lead(x)) & lead(angle_glitch) & (x == lead(x) | y == lead(y))

--- a/_Scripts/_settings.R
+++ b/_Scripts/_settings.R
@@ -118,10 +118,18 @@ redraw_filter_params <- list(
 # lifts their finger at all during the tracing). This filter tries to catch and
 # remove these glitch points so those trials don't need to be excluded.
 #
+# NOTE: The issue causing these glitches has long since been fixed, meaning this
+#       filter should no longer needed for new datasets. It is now disabled by
+#       default, but can be re-enabled below if needed.
+#
 # This filter has four parts: a filter that detects glitches based on angle and
 # distance, two filters that detect whether the first or last points of the
 # tracing are glitch points, respectively, and a final filter that detects
 # multiple glitches in a row when they share x or y positions.
+#
+# - 'enable': Whether the glitch filter is enabled or not. When applied to a
+#    dataset without touchscreen glitches it can create false positives, so it
+#    is disabled by default.
 #
 # - 'min_angle_diff': The minimum absolute change in direction (in degrees) from
 #    the jump towards a point vs the jump away from it for a point to be able to
@@ -140,6 +148,7 @@ redraw_filter_params <- list(
 #    point to be glitch).
 
 glitch_filter_params <- list(
+  enable = FALSE,
   min_angle_diff = 90,
   min_angle_diff_alt = 70,
   min_dist = 100

--- a/_Scripts/_settings.R
+++ b/_Scripts/_settings.R
@@ -70,6 +70,47 @@ done_filter_params <- list(
 )
 
 
+## "Redrawn Shape" Filter
+
+# Occasionally, participants will trace a shape but fail to end the trial,
+# then proceed to draw the whole shape a second time. This filter tries to
+# catch and remove the points belonging to the second tracing, leaving only
+# the original response.
+#
+# Since these trials are identified by a relatively long pause near the origin
+# point partway through the trial, this filter uses the same "pause near origin"
+# logic as the "trial done" filter above (just with different values) along with
+# a "proportion done" threshold to distinguish redrawn shape trials from other
+# "failed end" trials.
+#
+# - 'pause_radius': The distance from the origin (in px) within which a
+#    sufficiently long pause (as defined by 'min_pause') is considered to be
+#    the start of a second tracing.
+#
+# - 'end_prop': The minimum proportion of the tracing that needs to be complete
+#    before a sufficiently long pause can be considered the start of a second
+#    tracing.
+#
+# - 'max_prop': The maximum proportion of the tracing that can be complete for
+#    a sufficiently long pause to be considered the start of a second tracing.
+#
+# - 'min_pause': The minimum time difference (in sec) between two points in the
+#    middle of the trace (between 'end_prop' and 'max_prop') for the second
+#    point to be considered the start of a second tracing (provided that first
+#    point is within 'pause_radius' of the origin).
+
+redraw_filter_params <- list(
+  pause_radius = 300,
+  end_prop = 0.35,
+  max_prop = 0.7,
+  min_pause = 0.800,
+  # Dummy values for 'done' filter function
+  min_prop = 1.0,
+  origin_radius = 0,
+  end_radius = 0
+)
+
+
 ## Touchscreen Glitch Filter
 
 # Occasionally during a trial, the touchscreen glitches out and jumps the cursor


### PR DESCRIPTION
This PR makes some improvements to the tracing filtering process, including some adjustments to the glitch filter and the addition of a new filter to catch redrawn shapes.

For the glitch filter, this PR a) reduces false positives for consecutive glitches in old datasets, b) moves the glitch filter before the done filter so that glitches don't interfere with the logic for trimming end-of-trial samples, and c) disables the glitch filter by default since it is no longer needed for new datasets and mostly causes false positives (the cause of the glitches was a driver issue with the Planar touch screen on macOS and all recent studies have been done on either Linux or Windows).

The redrawn shape filter catches trials where the participant completes a tracing, misses the origin, and then decides to re-trace the entire shape again. Below is an example of what this looks like (red points are first tracing, blue points are second tracing within the same trial):
<img width="1035" height="613" alt="Screen Shot 2026-01-22 at 5 39 43 PM" src="https://github.com/user-attachments/assets/6f5627dd-6a24-4d06-a74a-7b705234cba1" />
