### PR TITLE
[WIP] Add support for aligning with DTW-by-angle 

### DIFF
--- a/_Scripts/1_preprocessing.R
+++ b/_Scripts/1_preprocessing.R
@@ -466,6 +466,27 @@ err_dtw_proc <- figtrace_dtw %>%
 
 
 
+### Perform accuracy analyses using dtw to align changes in turn angle ###
+
+# Align contours of tracing to stimulus using dynamic time warping
+
+figtrace_equidtw <- figtrace_equidist %>%
+  group_modify(~ dtw2df_angle(.$x, .$y, .$trace.x, .$trace.y))
+
+
+# Get dtw-by-angle error measures
+
+err_angle_dtw <- figtrace_equidtw %>%
+  mutate(err = line_length(x, y, tx, ty)) %>%
+  summarize(
+    dtw_angle_err_tot = sum(err),
+    dtw_angle_err_mean = mean(err),
+    dtw_angle_err_sd = sd(err),
+    dtw_angle_err_paired_sd = paired.sd(err)
+  )
+
+
+
 #### Merge summarized figure data with task data ####
 
 # Join all tracing summary data together
@@ -474,6 +495,7 @@ tracesummary <- tracesummary %>%
   left_join(err_raw, by = c("id", "session", "block", "trial")) %>%
   left_join(err_eqd, by = c("id", "session", "block", "trial")) %>%
   left_join(err_dtw, by = c("id", "session", "block", "trial")) %>%
+  left_join(err_angle_dtw, by = c("id", "session", "block", "trial")) %>%
   left_join(err_dtw_proc, by = c("id", "session", "block", "trial"))
 
 

--- a/_Scripts/_functions/physical.R
+++ b/_Scripts/_functions/physical.R
@@ -136,3 +136,49 @@ dtw2df <- function(x, y, tx, ty, step = asymmetric) {
 
   dtw_df
 }
+
+
+dtw2df_angle <- function(x, y, tx, ty, step = mori2006) {
+
+  # Get angle of movement for each consecutive pair of points
+  time <- seq_len(length(x)) * (1 / 60)
+  delt <- atan2(y - lag(y), x - lag(x))
+  tdelt <- atan2(ty - lag(ty), tx - lag(tx))
+
+  # Since angles wrap around from 0 to 360, we need to modify the DTW cost
+  # matrix so that all difference scores are within (-180, 180) and none of
+  # the differences are negative (which breaks the alignment)
+  cmat <- proxy::dist(
+    tdelt[!is.na(tdelt)], delt[!is.na(delt)],
+    method = "Euclidean"
+  )
+  cmat <- ifelse(cmat > pi, cmat - (2 * pi), cmat)
+  cmat <- ifelse(cmat < -pi, cmat + (2 * pi), cmat)
+  cmat <- abs(cmat)
+
+  # Do dynamic time warping and get warped dataframe
+  warped <- dtw(
+    x = cmat,
+    y = NULL,
+    step.pattern = step,
+    window.type = "none",
+    keep.internals = TRUE,
+    distance.only = FALSE,
+    open.end = FALSE,
+    open.begin = FALSE
+  )
+
+  # Return dataframe with warped stimulus and response points
+  dtw_df <- tibble(
+    tw = time[warped$index2 + 1],
+    x = x[warped$index2 + 1],
+    y = y[warped$index2 + 1],
+    delta = na.omit(delt)[warped$index2],
+    ttw = time[warped$index1 + 1],
+    tx = tx[warped$index1 + 1],
+    ty = ty[warped$index1 + 1],
+    tdelta = na.omit(tdelt)[warped$index1]
+  )
+
+  dtw_df
+}


### PR DESCRIPTION
Aligning tracings and figures has always been tricky, and the alignment methods we've used up to now have always left something to be desired when you plot them and see what they're actually connecting with what. To try and improve this, we want to add support for aligning shapes based on their *direction of movement*[^1] so that like features are connected between tracings and their corresponding parts on the shape.

Here are a few tracings from existing data where it's clear that what dtw-by-angle (right) is doing seems more reasonable than our current approach of dtw-by-distance (left):

<img width="1788" height="509" alt="Screen Shot 2026-01-23 at 1 34 56 PM" src="https://github.com/user-attachments/assets/97310b6f-8069-4efe-86eb-e07530fa183b" />

<img width="1785" height="506" alt="Screen Shot 2026-01-23 at 1 43 16 PM" src="https://github.com/user-attachments/assets/5ba67e72-1aa9-48b0-b9d9-a3a320e435e9" />

<img width="1787" height="514" alt="Screen Shot 2026-01-23 at 1 45 53 PM" src="https://github.com/user-attachments/assets/b9365e12-55dc-4256-b103-2841c8a5226c" />

What's surprising, however, is that this doesn't seem to have much effect at all on the measurement of learning in the data! Looking at the (repeated - random) effect sizes across sessions/conditions in Tony's original data, the effect sizes are actually slightly larger for dtw-by-distance (dtw) compared to dtw-by-angle:

<img width="887" height="396" alt="Screen Shot 2026-02-18 at 2 29 01 PM" src="https://github.com/user-attachments/assets/11074502-aae7-494d-abf6-8596c0ed0731" />

And here are effect sizes for repeated-shape improvement between session 5 vs 1 for the full-feedback (red) and no feedback (blue) PP groups in Tony's study, showing basically identical effects across metrics:

<img width="793" height="330" alt="Screen Shot 2026-02-18 at 2 26 57 PM" src="https://github.com/user-attachments/assets/29c8a7bd-5592-44e2-b612-673ed1aba467" />

On its face, aligning by angle seems to match my personal sense of what "comparing shapes" should look like, but it's weird it doesn't seem to be a clear improvement re: learning effects!

I think it's also worth mentioning that there's still room for improvement when aligning by angle. For example, with this shape you can see a common issue with dtw-by-angle alignment where because it's only concerned with angle of direction it's over-penalizing the final segment where the points are actually pretty close together: 

<img width="1788" height="511" alt="Screen Shot 2026-01-23 at 1 41 26 PM" src="https://github.com/user-attachments/assets/234a7505-4d07-4b9b-a6d5-320a1e044816" />

The only way I can think to fix this would be some sort of mixing dtw-by-distance and dtw-by-angle in the dtw penalty matrix, but that's a whole can of worms I haven't been keen on opening.

#### Correlation/angle metrics

I haven't added code for getting "correlation"/"absolute angle error" metrics yet because I haven't fully figured it out yet, but here's the bit I had for correlation locally:

```r
# Get dtw-by-angle error measures

err_angle_dtw <- figtrace_equidtw %>%
  mutate(err = line_length(x, y, tx, ty)) %>%
  summarize(
    dtw_angle_err_tot = sum(err),
    dtw_angle_err_mean = mean(err),
    dtw_angle_err_sd = sd(err),
    dtw_cor_err_mean = logit(Rfast2::circ.cor1(sin(delta), sin(tdelta))[[1]]),
  )
```
Basically, because `delta` and `tdelta` are directional vectors (i.e. what direction the tracing/figure are currently moving) they're angles in radians, which wrap from pi to -pi at a certain point. Since that means there are sometimes huge jumps in values due to slight changes in direction (e.g. 359° to 1°) we need to use a special function for *circular* correlation to properly handle this. For whatever reason (I didn't fully figure it out but found other people backing this up), these functions only work properly if you provide the sine of the angles instead of raw radians. Also since the output is on a scale from 0.0 to 1.0 I'm logit-transforming the result so it's vaguely normal.

Something worth noting here is that because we're using the `mori2006` symmetric step pattern you can get multiple tracing points connected to a single figure point as well as the usual vice versa. Not sure how much this really affects the math here but it does mean that values of `delta` and `tdelta` aren't necessarily consecutive:

<img width="569" height="173" alt="Screen Shot 2026-02-18 at 2 55 42 PM" src="https://github.com/user-attachments/assets/9cbfb2a8-a56f-4b4e-bfec-89659f84c726" />


[^1]: I also tried aligning shapes by *relative* changes in angle of movement but this was less reliable, and went off the rails easier when a feature was present in a figure but not a shape (or vice versa).